### PR TITLE
fix: fixed the TTL in redis cache

### DIFF
--- a/cache/cacheHelper.js
+++ b/cache/cacheHelper.js
@@ -18,7 +18,7 @@ redisClient.on("error", (err) => {
 
 
 exports.setCache = (key, value) => {
-    return redisClient.set(key, value, 'EX', 86400, function (err, reply) {
+    return redisClient.set(key, value, {EX:86400}, function (err, reply) {
         if (err) {
             console.error('Error setting key:', err);
         } else {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6d3beab4-d18b-4283-8e45-0c15bce9b3b2)
The TTL is fixed by passing the object instead of string in redisClient.set().
